### PR TITLE
Support for other sample rates

### DIFF
--- a/data_point_collector.py
+++ b/data_point_collector.py
@@ -16,8 +16,8 @@ import pickle
 #gazemap_images/
 #10_342.jpg
 
-
-def read_datasets(data_dir, in_sequences=False, keep_prediction_rate=True, longest_seq=None):
+def read_datasets(data_dir, in_sequences=False, keep_prediction_rate=True, \
+                    longest_seq=None, sample_rate=3):
     if in_sequences:
         if keep_prediction_rate:
             pickle_filename = "data_point_names_in_sequences.pickle"
@@ -25,13 +25,15 @@ def read_datasets(data_dir, in_sequences=False, keep_prediction_rate=True, longe
             pickle_filename = "data_point_names_in_sequences_for_visualization.pickle"
     else:
         pickle_filename = "data_point_names.pickle"
-    
+
     pickle_filepath = os.path.join(data_dir, pickle_filename)
     if not os.path.exists(pickle_filepath):
         directories = ['training', 'validation', 'application']
         data_point_names = {}
         for directory in directories:
-            data_point_names[directory] = get_data_point_names(data_dir+directory+'/', in_sequences, keep_prediction_rate, longest_seq=longest_seq)
+            data_point_names[directory] = get_data_point_names(data_dir+directory+'/', \
+                    in_sequences, keep_prediction_rate, longest_seq=longest_seq, \
+                    sample_rate=sample_rate)
         print ("Pickling ...")
         with open(pickle_filepath, 'wb') as f:
             pickle.dump(data_point_names, f, pickle.HIGHEST_PROTOCOL)
@@ -42,46 +44,61 @@ def read_datasets(data_dir, in_sequences=False, keep_prediction_rate=True, longe
 
     return data_point_names['training'], data_point_names['validation'], data_point_names['application']
 
-    
-def get_data_point_names(directory, in_sequences=False, keep_prediction_rate=True, predictionRate=3, longest_seq=None):
+
+def get_data_point_names(directory, in_sequences=False, keep_prediction_rate=True, \
+                            predictionRate=3, longest_seq=None, sampleRate=3):
     if not os.path.isdir(directory):
         print("Data directory '" + directory + "' not found.")
         return None
-    
+
     image_path = os.path.join(directory, 'camera_images')
     data_points = [f[:-4] for f in os.listdir(image_path) if f.endswith('.jpg')]
     data_points.sort()
-        
+
+    # Our model was trained at 3 Hz, so it only supports prediction at 3 frames/second.
+    # If a different sample rate is desired, we will sample more frames
+    # than needed, split them into groups of 3 frames per second,
+    # and train multiple times. (See group_num below)
+    if sampleRate % 3 == 0:
+        numGroups = sampleRate / 3
+    else:
+        numGroups = sampleRate
+
     if in_sequences:
         data_point_dict = {}
+
+        # Assign each frame a group number indicating which set it will be
+        # trained in. For example, if the desired rate is 4 Hz, we would sample
+        # 4x3=12 frames, then train 4 different groups at the default 3 Hz
+        # to get data for each frame.
+        group_num = 0
+
         for data_point in data_points:
             video_id = data_point.split('_')[0]
             if keep_prediction_rate:
-                timestamp = int(data_point.split('_')[1])
-                predictionInterval = round(1000.0/predictionRate)
-                group_key = video_id + '_' + str(int(round((timestamp%predictionInterval)/10.0))*10)
-                #print(data_point)
-                #print(group_key)
+                group_key = group_num
+                group_num = (group_num + 1) % numGroups
             else:
                 group_key = video_id
-            
+
             group = data_point_dict.setdefault(group_key, [])
             group.append(data_point)
+
         data_point_names = \
             list(data_point_dict.values())
     else:
         data_point_names = list(data_points)
-    
+
     if longest_seq is not None:
         #avoid sequences that are too long to avoid memory error
         size_threshold = longest_seq
         data_point_names = crop_long_seqs(data_point_names, size_threshold)
-    
+
     no_of_videos = len(data_point_names)
     print ('No. of %s videos: %d' % (directory, no_of_videos))
-    
+
     return data_point_names
-    
+
 
 
 def crop_long_seqs(data_point_names, size_threshold):
@@ -89,14 +106,9 @@ def crop_long_seqs(data_point_names, size_threshold):
     long_indices = [i for i,size in enumerate(sizes) if size>size_threshold]
     if len(long_indices) == 0:
         return data_point_names
-        
+
     for i in long_indices:
         seq = data_point_names[i]
         data_point_names.append(seq[size_threshold:])
         data_point_names[i] = seq[:size_threshold]
     return crop_long_seqs(data_point_names, size_threshold)
-        
-        
-        
-        
-        

--- a/data_point_collector_tests.py
+++ b/data_point_collector_tests.py
@@ -1,0 +1,51 @@
+import json
+from data_point_collector import *
+
+DATA_DIR = "./camera_images"
+
+def run_tests():
+    # Sample rates to test:
+    sample_rates = [3,  # The default prediction rate. Should only have 1 group.
+                    7,  # Not a multiple of 3 -- should have 7 groups
+                    6,  # Multiple of 3 -- should have 6/3=2 groups
+                    2]  # Less than 3 fps
+
+    for rate in sample_rates:
+        print("\n\nTESTING SAMPLE RATE: " + str(rate) + "\n\n")
+        test_group_assignment(rate)
+
+# Tests that frames get assigned to the correct group based on sample rate.
+def test_group_assignment(sample_rate):
+    PREDICTION_RATE = 3
+    NUM_SECONDS = 5
+
+    effective_rate = sample_rate if sample_rate % 3 == 0 \
+                        else sample_rate * PREDICTION_RATE
+
+
+    clear_old_files(DATA_DIR)
+    write_dummy_files(effective_rate * NUM_SECONDS, ".jpg", \
+                        DATA_DIR, "image")
+    result = get_data_point_names(".", in_sequences=True, sampleRate=sample_rate)
+
+    keys = list(range(len(result)))
+    dict_result = dict(zip(keys, result))
+    print("GROUPS", json.dumps(dict_result, indent=2))
+    print("Return value", result)
+
+def leftpad(text, length, pad_char=0):
+    while len(text) < length:
+        text = str(pad_char) + text
+    return text
+
+# Writes dummy .jpg files to test the data point grouping.
+def write_dummy_files(num_files, extension, directory, name_prefix="test"):
+    for i in range(num_files):
+        f = open(directory + "/" + name_prefix + leftpad(str(i), 5) + extension,"w+")
+        f.close()
+
+def clear_old_files(directory):
+    files = os.listdir(directory)
+    for item in files:
+        if item.endswith(".jpg"):
+            os.remove(os.path.join(directory, item))


### PR DESCRIPTION
Our model was trained at 3 Hz, so by default it didn't support predicting at other rates.

The solution was to split the frames into groups and then run each group through the model separately. For example, if the desired sample rate is 6 Hz, we split it into 2 groups for prediction at 3 Hz each. If the sample rate is not a multiple of 3, we first sample more frames than necessary -- for example, for 4 Hz, we would sample 4x3=12 frames per second, then split it into 4 groups.

Also includes demo/tests of this method in `data_point_collector_tests.py`